### PR TITLE
Resume PDF: better pagination + force filename

### DIFF
--- a/billock-org/src/components/people/resume/Education.jsx
+++ b/billock-org/src/components/people/resume/Education.jsx
@@ -24,8 +24,8 @@ export default class Education extends Component {
     ]);
   }
   render() {
-    var education_list = this.getData().map( (item) => 
-      <div key={uuidv4()}>
+    var education_list = this.getData().map( (item) =>
+      <div key={uuidv4()} className='resume-entry'>
         <div>
           <span className="degree">
             {item['degree']}

--- a/billock-org/src/components/people/resume/EmploymentHistory.jsx
+++ b/billock-org/src/components/people/resume/EmploymentHistory.jsx
@@ -246,8 +246,8 @@ export default class EmploymentHistory extends Component {
     ]);
   }
   render() {
-    var employment_list = this.getData().map( (item) => 
-      <div key={uuidv4()}>
+    var employment_list = this.getData().map( (item) =>
+      <div key={uuidv4()} className='resume-entry'>
         <div>
           <span className="datespan">{item['start-date']}-{item['end-date'] === undefined ? 'Present' : item['end-date']}</span>
           &nbsp;----&nbsp;

--- a/billock-org/src/components/people/resume/OtherRelated.jsx
+++ b/billock-org/src/components/people/resume/OtherRelated.jsx
@@ -72,8 +72,8 @@ export default class OtherRelated extends Component {
     ]
   }
   render() {
-    const item_list = this.getData().map((item) => 
-      <div key={uuidv4()}>
+    const item_list = this.getData().map((item) =>
+      <div key={uuidv4()} className='resume-entry'>
         <span className='company-location'>{item['data']}</span>
         <ul>
           {item['children'].map((child) => <li key={uuidv4()}>{child}</li>)}

--- a/billock-org/src/components/people/resume/index.jsx
+++ b/billock-org/src/components/people/resume/index.jsx
@@ -7,6 +7,13 @@ import '../../../stylesheets/resume.sass'
 
 export default class Resume extends Component {
   generatePDF = () => {
+    const originalTitle = document.title
+    document.title = 'willow-billock-resume'
+    const restore = () => {
+      document.title = originalTitle
+      window.removeEventListener('afterprint', restore)
+    }
+    window.addEventListener('afterprint', restore)
     window.print()
   }
   render() {

--- a/billock-org/src/stylesheets/resume.sass
+++ b/billock-org/src/stylesheets/resume.sass
@@ -52,7 +52,11 @@
         margin: 0.05em 0
         page-break-inside: avoid
 
-    #resume-content > div
+    #resume-content h1,
+    #resume-content h2
+        page-break-after: avoid
+
+    .resume-entry
         page-break-inside: avoid
 
     .resume-print-btn


### PR DESCRIPTION
## Summary

Follow-up improvements to the print-based resume export landed in #19.

### 1. Force filename to `willow-billock-resume`

Browsers use `document.title` as the default name in the "Save as PDF" dialog. The page title is "The Billock family", so the suggested filename was wrong. Now `generatePDF` temporarily sets `document.title` to `willow-billock-resume`, prints, and restores the original title on the `afterprint` event.

### 2. Better pagination

The previous CSS used `page-break-inside: avoid` on `#resume-content > div`, which asked the browser to keep entire sections together. With 15 employment entries, that's impossible — so the browser broke arbitrarily and wasted page 1.

Switched to per-entry `.resume-entry` class added to each item in `EmploymentHistory`, `Education`, and `OtherRelated`. Now individual entries stay intact while sections flow across pages naturally. Added `page-break-after: avoid` on `h1`/`h2` to prevent orphan section headings at page bottom.

## Test plan
- [ ] Click "Export PDF" → file save dialog shows `willow-billock-resume.pdf` as default
- [ ] PDF has no mid-entry page breaks (Invoice2go's last bullet should stay with the rest of the entry)
- [ ] Section headings (e.g., "Employment") don't end up alone at the bottom of a page
- [ ] Page 1 is fully utilized (Skills + start of Employment, not just Skills with whitespace)

https://claude.ai/code/session_018YaXdwhDMEZVh7n1UBhnUP

---
_Generated by [Claude Code](https://claude.ai/code/session_018YaXdwhDMEZVh7n1UBhnUP)_