### PR TITLE
Resume PDF: add explicit left/right margins via padding

### DIFF
--- a/billock-org/src/stylesheets/resume.sass
+++ b/billock-org/src/stylesheets/resume.sass
@@ -15,7 +15,7 @@
 @media print
     @page
         size: letter
-        margin: 0.6in
+        margin: 0.5in 0
 
     body *
         visibility: hidden
@@ -29,6 +29,8 @@
         left: 0
         top: 0
         width: 100%
+        box-sizing: border-box
+        padding: 0 0.5in
         color: #000
         background: #fff
         font-size: 10pt


### PR DESCRIPTION
## Summary

The latest exported resume PDF had `xMin=0` for content — text was rendering flush against the page's left edge. The `@page { margin: 0.6in }` rule wasn't being respected for the horizontal axis once `#resume-content` was set to `position: absolute; left: 0`.

## Fix

- Switch `@page` to `margin: 0.5in 0` — top/bottom only. The print engine reliably reserves vertical white space across page breaks for those.
- Add `padding: 0 0.5in` plus `box-sizing: border-box` to `#resume-content`. CSS padding on the inline axis is applied consistently on every page when content overflows, so the left/right margins stay 0.5" on every page regardless of the print dialog's "Margins" setting.

## Test plan
- [ ] Export PDF → text has ~0.5" white space on left and right edges of every page
- [ ] Top/bottom of each page also has 0.5" white space (assuming user uses Default margins in print dialog)
- [ ] No content gets clipped at edges
- [ ] Pagination behavior from #20 still works (entries don't split mid-bullet)

https://claude.ai/code/session_018YaXdwhDMEZVh7n1UBhnUP

---
_Generated by [Claude Code](https://claude.ai/code/session_018YaXdwhDMEZVh7n1UBhnUP)_