### PR TITLE
npm audit fix: 28 -> 27 vulnerabilities

### DIFF
--- a/billock-org/package-lock.json
+++ b/billock-org/package-lock.json
@@ -15701,9 +15701,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -26820,9 +26821,9 @@
       }
     },
     "ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "requires": {}
     },
     "xml-name-validator": {


### PR DESCRIPTION
## Summary

Runs `npm audit fix` against the current lockfile. Drops 28 → 27 vulnerabilities — only one had a non-breaking patch available. All remaining 27 vulns require `--force` (breaking changes) and are concentrated in transitive dev deps that ship with `react-scripts@5.0.0`:

- `minimatch` (high, ReDoS) — pulled by `ftp-deploy` + `recursive-readdir`
- `nth-check` (high) — pulled by `svgo` → CRA's image processing
- `postcss` (moderate) — pulled by `resolve-url-loader`
- `serialize-javascript` (high) — pulled by `terser-webpack-plugin`
- `webpack-dev-server` (moderate) — only matters for dev server, not production
- `react-router` (moderate) — patch will land when react-router-dom updates

These are best handled by upgrading `react-scripts` itself in a separate, deliberate pass (probably to a CRA fork like `react-scripts-rewired` or migrating to Vite, since CRA is unmaintained).

## Verification

- `npm run build` succeeds on the new lockfile
- 13-line lockfile diff (7 additions, 6 deletions) — minor transitive bump

## Test plan
- [ ] CI build & deploy run on this PR succeeds
- [ ] Live site loads after deploy

https://claude.ai/code/session_018YaXdwhDMEZVh7n1UBhnUP

---
_Generated by [Claude Code](https://claude.ai/code/session_018YaXdwhDMEZVh7n1UBhnUP)_