### PR TITLE
Fix background cropping on short people pages

### DIFF
--- a/billock-org/src/stylesheets/main.sass
+++ b/billock-org/src/stylesheets/main.sass
@@ -13,7 +13,7 @@ html,
         repeat: repeat
         size: cover
     width: 100%
-    min-height: 100%
+    min-height: 100vh
     float: left
     background-attachment: fixed
   


### PR DESCRIPTION
## Summary

The Connor/Willow/Kiley/Luella pages share a `@mixin background(...)` defined in `main.sass`. That mixin set `min-height: 100%`, which collapses to the content's height when there isn't much — leaving large white areas below the bg image on tall desktop viewports.

Changed to `min-height: 100vh` so the bg div always fills at least the viewport. With `background-attachment: fixed` already in place, the image now shows through correctly regardless of content length.

The home page wasn't affected — it has its own mixin in `home.sass` that already used `100vh`.

## Test plan
- [ ] Visit `/connor` on desktop → background fills viewport (was: cropped to ~150px)
- [ ] Visit `/willow`, `/kiley`, `/luella` → same
- [ ] Visit `/` → unchanged
- [ ] Mobile view of all four people pages still scrolls correctly

https://claude.ai/code/session_018YaXdwhDMEZVh7n1UBhnUP

---
_Generated by [Claude Code](https://claude.ai/code/session_018YaXdwhDMEZVh7n1UBhnUP)_